### PR TITLE
fixes #1

### DIFF
--- a/particlesystem/src/main/java/me/nikhilchaudhari/quarks/core/Constants.kt
+++ b/particlesystem/src/main/java/me/nikhilchaudhari/quarks/core/Constants.kt
@@ -1,5 +1,7 @@
 package me.nikhilchaudhari.quarks.core
 
+import java.math.RoundingMode
+
 
 const val PI = Math.PI
 const val HALF_PI = PI / 2
@@ -9,9 +11,9 @@ const val QUARTER_PI = PI / 4
 
 
 fun Float.roundTo(n : Int) : Float {
-    return "%.${n}f".format(this).toFloat()
+    return this.toBigDecimal().setScale(n, RoundingMode.UP).toFloat()
 }
 
 fun Double.roundTo(n : Int) : Double {
-    return "%.${n}f".format(this).toDouble()
+    return this.toBigDecimal().setScale(n, RoundingMode.UP).toDouble()
 }


### PR DESCRIPTION
String format method uses Locale behind the scenes that causes crashes in some locales that use "," as a decimal separator.
Changed to BigDecimal setscale function instead.